### PR TITLE
Release reset pin instead of driving high (EUB-103)

### DIFF
--- a/components/debug_probe/debug_gpio.h
+++ b/components/debug_probe/debug_gpio.h
@@ -9,6 +9,7 @@
 #include <driver/gpio.h>
 #include <driver/dedic_gpio.h>
 #include <hal/dedic_gpio_cpu_ll.h>
+#include "soc/gpio_reg.h"
 #include "hal/gpio_ll.h"
 #include "compiler.h"
 #include "sdkconfig.h"

--- a/components/serial_handler/serial_handler.c
+++ b/components/serial_handler/serial_handler.c
@@ -159,6 +159,16 @@ static esp_err_t init_uart_transport(void)
         // Enable pull up for RXD to avoid floating input
         ESP_RETURN_ON_ERROR(gpio_pullup_en(GPIO_RXD), TAG, "Failed to enable pull up for RXD");
 
+        // Override BOOT/RST pins to open-drain so the bridge never actively drives them HIGH.
+        // The internal pull-ups (and any external pull-ups on the target) define the idle HIGH level,
+        // while other devices can still pull the lines LOW without bus contention.
+        ESP_RETURN_ON_ERROR(gpio_set_direction(GPIO_BOOT, GPIO_MODE_OUTPUT_OD), TAG, "Failed to set boot pin to open-drain");
+        ESP_RETURN_ON_ERROR(gpio_pullup_en(GPIO_BOOT), TAG, "Failed to enable pull up for BOOT");
+        ESP_RETURN_ON_ERROR(gpio_set_level(GPIO_BOOT, 1), TAG, "Failed to release boot pin");
+        ESP_RETURN_ON_ERROR(gpio_set_direction(GPIO_RST, GPIO_MODE_OUTPUT_OD), TAG, "Failed to set reset pin to open-drain");
+        ESP_RETURN_ON_ERROR(gpio_pullup_en(GPIO_RST), TAG, "Failed to enable pull up for RST");
+        ESP_RETURN_ON_ERROR(gpio_set_level(GPIO_RST, 1), TAG, "Failed to release reset pin");
+
         ESP_LOGI(TAG, "UART have been initialized");
 
         // Start UART event task

--- a/main/main.c
+++ b/main/main.c
@@ -13,7 +13,6 @@
 #include "msc.h"
 #include "serial_handler.h"
 #include "serial_bridge.h"
-#include "hal/usb_phy_types.h"
 #include "rom/gpio.h"
 #include "driver/gpio.h"
 #include "sdkconfig.h"


### PR DESCRIPTION
## Description

When programming an esp32 device that is in circuit with another device such as another mcu or fpga, the other device is unable to reset the esp32 while the programmer is connected as the programmer drives the reset pin high when it is not trying to reset.

Instead of driving the reset pin high, the programmer now releases it be pulled high by an external pullup,  This enables other devices to pull the target reset pin low if so needed.
